### PR TITLE
remove a character that was garbled

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ List of useful, silly and [awesome](#awesome-) lists curated on GitHub. Contribu
   - https://curatedseotools.com
 * [cycle-ecosystem](https://github.com/Widdershin/cycle-ecosystem) – What are the most popular and trending libraries for [Cycle.js](http://cycle.js.org/)?
 * [dad-jokes](https://github.com/wesbos/dad-jokes) – Dad style programming jokes.
-* [dark-knowledge](https://github.com/prescience-data/dark-knowledge) – Research papers and presentations for counter-detection and web privacy enthusiasts.
+* [dark-knowledge](https://github.com/prescience-data/dark-knowledge) – Research papers and presentations for counter-detection and web privacy enthusiasts.
 * [datajournalists-toolbox](https://github.com/basilesimon/datajournalists-toolbox) – Tools for datajournalists, with examples and gists.
 * [datascience](https://github.com/r0f1/datascience) – Python resources for data science.
 * [data-science-blogs](https://github.com/rushter/data-science-blogs)


### PR DESCRIPTION
I removed a character garbled between 'R' and 'esearch'.
![image](https://user-images.githubusercontent.com/33287918/209103316-a6ff6ff2-a7c1-478b-840a-95c39cd5d68d.png)
